### PR TITLE
runtime fallback to inmemory cache

### DIFF
--- a/CachedAPI/Controllers/QuoteController.cs
+++ b/CachedAPI/Controllers/QuoteController.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Memory;
 
 using Jeffsum;
 using static Jeffsum.Goldblum;

--- a/CachedAPI/Program.cs
+++ b/CachedAPI/Program.cs
@@ -47,20 +47,16 @@ public static class ICacheHelper
     {
         IConnectionMultiplexer multiplexer;
         var _logger = services.BuildServiceProvider().GetService<ILogger<Program>>();
-        
-        try
-        {
-            var connectionString = configuration
-                .GetValue<string>("RedisConnectionString");
-            multiplexer = ConnectionMultiplexer.Connect(connectionString);
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogError(ex, "### Error initialising RedisCache, Fallback to IMemoryCache");
 
-            services.ConfigureICacheServiceInMemory();
-            return services;
-        }
+        var connectionString = configuration
+            .GetValue<string>("RedisConnectionString");
+        ConfigurationOptions redisOptions = new ConfigurationOptions
+        {
+            EndPoints = { connectionString },
+            AbortOnConnectFail = false
+        };
+
+        multiplexer = ConnectionMultiplexer.Connect(redisOptions);
 
         services.AddSingleton<IConnectionMultiplexer>(multiplexer);
         services.AddTransient<ICacheService, RedisService>();
@@ -73,5 +69,4 @@ public static class ICacheHelper
 
         return services;
     }
-
 }

--- a/CachedAPI/Program.cs
+++ b/CachedAPI/Program.cs
@@ -56,7 +56,7 @@ public static class ICacheHelper
         }
         catch (Exception ex)
         {
-            _logger?.LogError("### Error initialising RedisCache, Fallback to IMemoryCache", ex);
+            _logger?.LogError(ex, "### Error initialising RedisCache, Fallback to IMemoryCache");
 
             services.ConfigureICacheServiceInMemory();
             return services;
@@ -64,6 +64,10 @@ public static class ICacheHelper
 
         services.AddSingleton<IConnectionMultiplexer>(multiplexer);
         services.AddTransient<ICacheService, RedisService>();
+
+        //Configure InMemoryCache for runtime fallback
+        services.AddMemoryCache();
+        services.AddTransient<InMemoryCacheService>();
 
         _logger?.LogInformation("### Successfully initialised RedisCache!");
 

--- a/CachedAPI/Services/RedisService.cs
+++ b/CachedAPI/Services/RedisService.cs
@@ -9,7 +9,7 @@ public class RedisService : ICacheService
 
     private readonly ILogger<RedisService> logger;
     private readonly InMemoryCacheService inMemoryCacheService;
-    private static bool EnableFallback = false;
+    private static bool IsFallbackEnabled = false;
 
     public RedisService(
         IConnectionMultiplexer connectionMultiplexer,
@@ -25,7 +25,7 @@ public class RedisService : ICacheService
         string Key, 
         CancellationToken cancellationToken = default)
     {
-        if (EnableFallback) 
+        if (IsFallbackEnabled) 
         {
             return await inMemoryCacheService
                 .GetCacheValueAsync<T>(Key, cancellationToken);
@@ -40,7 +40,7 @@ public class RedisService : ICacheService
         catch(Exception e)
         {
             logger.LogError(e, "### Redis Cache unreachable !!!");
-            EnableFallback = true;
+            IsFallbackEnabled = true;
             return default;
         }
 
@@ -69,7 +69,7 @@ public class RedisService : ICacheService
         string Key, 
         T Value, CancellationToken cancellationToken = default) where T : class
     {
-        if (EnableFallback)
+        if (IsFallbackEnabled)
         {
             await inMemoryCacheService
                 .SetCacheValueAsync<T>(
@@ -103,7 +103,7 @@ public class RedisService : ICacheService
         catch(Exception e)
         {
             logger.LogError(e, "### Redis Cache unreachable !!!");
-            EnableFallback = true;
+            IsFallbackEnabled = true;
             await inMemoryCacheService.SetCacheValueAsync(
                 Key, 
                 Value, 


### PR DESCRIPTION
Quick and dirty attempt to fallback to an IMemoryCache on redis disconnection during runtime.

TODO: Disable fallback when redis gets available again